### PR TITLE
docs: update CHANGELOG.md for v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.3.2] - 2024-05-01
+### :bug: Bug Fixes
+- [`4ded426`](https://github.com/alex289/CleanArchitecture/commit/4ded4263566315bad6208e7138d13d72532a728f) - Setting the right variable *(commit by [@alex289](https://github.com/alex289))*
+
+
 ## [v1.3.1] - 2024-05-01
 ### :bug: Bug Fixes
 - [`3de46b4`](https://github.com/alex289/CleanArchitecture/commit/3de46b4eccb90456bb08a04c444f2c3113c93b8d) - Use correct tags when pushing docker image *(commit by [@alex289](https://github.com/alex289))*
@@ -60,3 +65,4 @@ _This is the initial release._
 [v1.2.0]: https://github.com/alex289/CleanArchitecture/compare/v1.1.3...v1.2.0
 [v1.3.0]: https://github.com/alex289/CleanArchitecture/compare/v1.2.0...v1.3.0
 [v1.3.1]: https://github.com/alex289/CleanArchitecture/compare/v1.3.0...v1.3.1
+[v1.3.2]: https://github.com/alex289/CleanArchitecture/compare/v1.3.1...v1.3.2


### PR DESCRIPTION
This PR updates the CHANGELOG.md file for the release of version v1.3.2.